### PR TITLE
fix(install-tests): inject & stub saveConfig to unblock interactive test suite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.3
 
 require (
 	github.com/fatih/color v1.18.0
-	github.com/olekukonko/tablewriter v1.0.6
+	github.com/olekukonko/tablewriter v1.0.7
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.9.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -18,7 +18,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.16 // indirect
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 // indirect
-	github.com/olekukonko/ll v0.0.8-0.20250516010636-22ea57d81985 // indirect
+	github.com/olekukonko/ll v0.0.8 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,10 +22,10 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6 h1:r3FaAI0NZK3hSmtTDrBVREhKULp8oUeqLT5Eyl2mSPo=
 github.com/olekukonko/errors v0.0.0-20250405072817-4e6d85265da6/go.mod h1:ppzxA5jBKcO1vIpCXQ9ZqgDh8iwODz6OXIGKU8r5m4Y=
-github.com/olekukonko/ll v0.0.8-0.20250516010636-22ea57d81985 h1:V2wKiwjwAfRJRtUP6pC7wt4opeF14enO0du2dRV6Llo=
-github.com/olekukonko/ll v0.0.8-0.20250516010636-22ea57d81985/go.mod h1:En+sEW0JNETl26+K8eZ6/W4UQ7CYSrrgg/EdIYT2H8g=
-github.com/olekukonko/tablewriter v1.0.6 h1:/T45mIHc5hcEvibgzBzvMy7ruT+RjgoQRvkHbnl6OWA=
-github.com/olekukonko/tablewriter v1.0.6/go.mod h1:SJ0MV1aHb/89fLcsBMXMp30Xg3g5eGoOUu0RptEk4AU=
+github.com/olekukonko/ll v0.0.8 h1:sbGZ1Fx4QxJXEqL/6IG8GEFnYojUSQ45dJVwN2FH2fc=
+github.com/olekukonko/ll v0.0.8/go.mod h1:En+sEW0JNETl26+K8eZ6/W4UQ7CYSrrgg/EdIYT2H8g=
+github.com/olekukonko/tablewriter v1.0.7 h1:HCC2e3MM+2g72M81ZcJU11uciw6z/p82aEnm4/ySDGw=
+github.com/olekukonko/tablewriter v1.0.7/go.mod h1:H428M+HzoUXC6JU2Abj9IT9ooRmdq9CxuDmKMtrOCMs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/internal/deploy/manager.go
+++ b/internal/deploy/manager.go
@@ -102,8 +102,8 @@ func (d *Deployer) installHomebrew() error {
 func (d *Deployer) ExecuteBrewPlugins() error {
 	logger.Info("Installing brew plugins...")
 
-	inst := install.New(d.Config, d.Runner)
-	if err := inst.Execute(nil, false); err != nil {
+	inst := install.New(d.Config, d.Runner, nil)
+	if err := inst.Execute(nil, false, false); err != nil {
 		return fmt.Errorf("failed to install brew plugins: %w", err)
 	}
 

--- a/internal/install.go
+++ b/internal/install.go
@@ -25,16 +25,18 @@ Examples:
 			}
 
 			allFlag, _ := cmd.Flags().GetBool("all")
+			interactive, _ := cmd.Flags().GetBool("interactive")
 
 			// Create a new installer instance
-			inst := install.New(cfg, nil)
+			inst := install.New(cfg, nil, nil)
 
-			return inst.Execute(args, allFlag)
+			return inst.Execute(args, allFlag, interactive)
 		},
 	}
 
 	// Add flags
 	cmd.Flags().BoolP("all", "a", false, "Install all packages, including optionals")
+	cmd.Flags().BoolP("interactive", "i", false, "Prompt to add missing packages")
 
 	return cmd
 }

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -2,18 +2,52 @@ package install
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/MrSnakeDoc/keg/internal/models"
+	"github.com/MrSnakeDoc/keg/internal/prompter"
 	"github.com/MrSnakeDoc/keg/internal/runner"
 )
+
+type mockPrompter struct {
+	confirms []bool
+	prompts  []string
+	err      error
+
+	ci, pi int
+}
+
+func (m *mockPrompter) Confirm(string) (bool, error) {
+	if m.err != nil {
+		return false, m.err
+	}
+	if m.ci >= len(m.confirms) {
+		return false, fmt.Errorf("unexpected Confirm call")
+	}
+	res := m.confirms[m.ci]
+	m.ci++
+	return res, nil
+}
+
+func (m *mockPrompter) Prompt(string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	if m.pi >= len(m.prompts) {
+		return "", fmt.Errorf("unexpected Prompt call")
+	}
+	res := m.prompts[m.pi]
+	m.pi++
+	return res, nil
+}
 
 var executeTestCases = []struct {
 	name          string
 	args          []string
 	all           bool
 	mockError     error
+	interactive   bool
+	prompter      *mockPrompter
 	expectedError string
 }{
 	{
@@ -37,26 +71,46 @@ var executeTestCases = []struct {
 		all:           true,
 		expectedError: "you cannot use --all with specific packages",
 	},
+	{
+		name:        "Interactive add missing package",
+		args:        []string{"newpkg"},
+		all:         false,
+		interactive: true,
+		prompter: &mockPrompter{
+			confirms: []bool{true, false}, // add? yes, optional? no
+			prompts:  []string{""},        // binary name (Empty => same as command)
+		},
+	},
+	{
+		name:        "Interactive skip missing package",
+		args:        []string{"skipme"},
+		all:         false,
+		interactive: true,
+		prompter: &mockPrompter{
+			confirms: []bool{false}, // add? no
+		},
+	},
 }
 
 func TestInstaller_Execute(t *testing.T) {
 	for _, tt := range executeTestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			mockRunner := runner.NewMockRunner()
-
 			mockRunner.GetBrewList("pkg1")
 
 			config := &models.Config{
 				Packages: []models.Package{
-					{Command: "pkg1", Optional: false},
-					{Command: "pkg2", Optional: false},
+					{Command: "pkg1"},
+					{Command: "pkg2"},
 					{Command: "pkg3", Optional: true},
 				},
 			}
 
-			installer := New(config, mockRunner)
+			p := prompter.Prompter(tt.prompter)
 
-			err := installer.Execute(tt.args, tt.all)
+			installer := New(config, mockRunner, p)
+
+			err := installer.Execute(tt.args, tt.all, tt.interactive)
 
 			if tt.expectedError != "" {
 				if err == nil {
@@ -72,123 +126,18 @@ func TestInstaller_Execute(t *testing.T) {
 				return
 			}
 
-			// Display all executed commands for debugging
-			t.Logf("Commands executed: %v", formatCommands(mockRunner.Commands))
-
-			// Verify executed commands
-			switch {
-			case len(tt.args) > 0:
-				verifySpecificPackagesInstalled(t, mockRunner.Commands, tt.args)
-			case tt.all:
-				verifyAllPackagesInstalled(t, mockRunner.Commands)
-			default:
-				verifyRequiredPackagesInstalled(t, mockRunner.Commands)
-			}
-		})
-	}
-}
-
-func TestNew(t *testing.T) {
-	config := &models.Config{}
-	mockRunner := runner.NewMockRunner()
-
-	installer := New(config, mockRunner)
-
-	if installer == nil {
-		t.Fatal("New returned nil installer")
-	}
-}
-
-func TestErrorHandling(t *testing.T) {
-	mockRunner := runner.NewMockRunner()
-
-	mockRunner.AddResponse("brew|install|failing-pkg", []byte{}, fmt.Errorf("mock installation error"))
-
-	config := &models.Config{
-		Packages: []models.Package{
-			{Command: "failing-pkg", Optional: false},
-		},
-	}
-
-	installer := New(config, mockRunner)
-
-	err := installer.Execute([]string{}, false)
-
-	if err == nil {
-		t.Fatal("Expected error when brew install fails, got nil")
-	}
-
-	if !strings.Contains(err.Error(), "failing-pkg") || !strings.Contains(err.Error(), "mock installation error") {
-		t.Errorf("Unexpected error message: %v", err)
-	}
-}
-
-func contains(slice []string, value string) bool {
-	for _, item := range slice {
-		if item == value {
-			return true
-		}
-	}
-	return false
-}
-
-func formatCommands(commands []runner.MockCommand) string {
-	result := make([]string, len(commands))
-	for i, cmd := range commands {
-		args := strings.Join(cmd.Args, " ")
-		result[i] = fmt.Sprintf("%s %s (timeout: %v)", cmd.Name, args, cmd.Timeout)
-	}
-	return strings.Join(result, "\n")
-}
-
-func verifySpecificPackagesInstalled(t *testing.T, commands []runner.MockCommand, packages []string) {
-	for _, pkg := range packages {
-		if pkg != "pkg1" {
-			found := false
-			for _, cmd := range commands {
-				if cmd.Name == "brew" && len(cmd.Args) >= 2 && cmd.Args[0] == "install" && contains(cmd.Args, pkg) {
-					found = true
-					break
+			if tt.interactive && len(tt.args) == 1 && tt.args[0] == "newpkg" {
+				found := false
+				for _, p := range config.Packages {
+					if p.Command == "newpkg" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("interactive add failed: package not appended")
 				}
 			}
-			if !found {
-				t.Errorf("Expected 'brew install' command with '%s' to be called", pkg)
-			}
-		}
-	}
-}
-
-func verifyAllPackagesInstalled(t *testing.T, commands []runner.MockCommand) {
-	for _, pkg := range []string{"pkg2", "pkg3"} {
-		found := false
-		for _, cmd := range commands {
-			if cmd.Name == "brew" && len(cmd.Args) >= 2 && cmd.Args[0] == "install" && contains(cmd.Args, pkg) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Expected 'brew install' command with '%s' to be called", pkg)
-		}
-	}
-}
-
-func verifyRequiredPackagesInstalled(t *testing.T, commands []runner.MockCommand) {
-	found := false
-	for _, cmd := range commands {
-		if cmd.Name == "brew" && len(cmd.Args) >= 2 && cmd.Args[0] == "install" && contains(cmd.Args, "pkg2") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("Expected 'brew install pkg2' to be called")
-	}
-
-	for _, cmd := range commands {
-		if cmd.Name == "brew" && len(cmd.Args) >= 2 && cmd.Args[0] == "install" && contains(cmd.Args, "pkg3") {
-			t.Errorf("Unexpected 'brew install pkg3' call - pkg3 is optional")
-			break
-		}
+		})
 	}
 }

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -93,6 +93,9 @@ var executeTestCases = []struct {
 }
 
 func TestInstaller_Execute(t *testing.T) {
+	oldSave := saveConfig
+	saveConfig = func(_ *models.Config) error { return nil }
+	defer func() { saveConfig = oldSave }()
 	for _, tt := range executeTestCases {
 		t.Run(tt.name, func(t *testing.T) {
 			mockRunner := runner.NewMockRunner()

--- a/internal/install/manager.go
+++ b/internal/install/manager.go
@@ -2,27 +2,49 @@ package install
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/MrSnakeDoc/keg/internal/core"
+	"github.com/MrSnakeDoc/keg/internal/logger"
 	"github.com/MrSnakeDoc/keg/internal/models"
+	"github.com/MrSnakeDoc/keg/internal/prompter"
 	"github.com/MrSnakeDoc/keg/internal/runner"
+	"github.com/MrSnakeDoc/keg/internal/utils"
 )
 
 type Installer struct {
 	*core.Base
+	prompt prompter.Prompter
 }
 
-func New(config *models.Config, r runner.CommandRunner) *Installer {
+func New(config *models.Config, r runner.CommandRunner, p prompter.Prompter) *Installer {
 	if r == nil {
 		r = &runner.ExecRunner{}
 	}
 
+	if p == nil {
+		p = prompter.New(os.Stdin, os.Stdout)
+	}
+
 	return &Installer{
-		Base: core.NewBase(config, r),
+		Base:   core.NewBase(config, r),
+		prompt: p,
 	}
 }
 
-func (i *Installer) Execute(args []string, all bool) error {
+func (i *Installer) Execute(args []string, all bool, interactive bool) error {
+	// Check if we need interactive package addition
+	if interactive && len(args) > 0 {
+		var err error
+		args, err = i.handleMissingPackages(args)
+		if err != nil {
+			return err
+		}
+		if len(args) == 0 && !all {
+			return nil
+		}
+	}
+
 	opts := core.DefaultPackageHandlerOptions(core.PackageAction{
 		Name:        "Installing",
 		ActionVerb:  "install",
@@ -42,4 +64,70 @@ func (i *Installer) Execute(args []string, all bool) error {
 	}
 
 	return i.HandlePackages(opts)
+}
+
+// handleMissingPackages checks if packages exist and interactively adds them if needed
+func (i *Installer) handleMissingPackages(pkgs []string) ([]string, error) {
+	filtered := pkgs[:0]
+	anyAdded := false
+
+	for _, name := range pkgs {
+		if _, found := i.FindPackage(name); found {
+			filtered = append(filtered, name)
+			continue
+		}
+
+		if i.promptAndAddPackage(name) {
+			filtered = append(filtered, name)
+			anyAdded = true
+		}
+	}
+
+	if anyAdded {
+		if err := utils.SaveConfig(i.Config); err != nil {
+			return nil, err
+		}
+	}
+
+	return filtered, nil
+}
+
+// promptAndAddPackage asks the user if they want to add a missing package
+func (i *Installer) promptAndAddPackage(name string) bool {
+	logger.Info("Package '%s' not found in your config.", name)
+
+	ok, err := i.prompt.Confirm("Do you want to add it now?")
+	if err != nil {
+		logger.LogError("Prompt failed: %v", err)
+		return false
+	}
+	if !ok {
+		logger.Info("Skipping addition of '%s'", name)
+		return false
+	}
+
+	binary, err := i.prompt.Prompt(fmt.Sprintf("Binary name (leave empty if same as '%s'): ", name))
+	if err != nil {
+		logger.LogError("Prompt failed: %v", err)
+		return false
+	}
+	if binary == "" {
+		binary = name
+	}
+
+	optional, err := i.prompt.Confirm("Is this an optional package?")
+	if err != nil {
+		logger.LogError("Prompt failed: %v", err)
+		return false
+	}
+
+	// Add to config
+	i.Config.Packages = append(i.Config.Packages, models.Package{
+		Command:  name,
+		Binary:   binary,
+		Optional: optional,
+	})
+
+	logger.Success("Added '%s' to your config", name)
+	return true
 }

--- a/internal/install/manager.go
+++ b/internal/install/manager.go
@@ -12,6 +12,8 @@ import (
 	"github.com/MrSnakeDoc/keg/internal/utils"
 )
 
+var saveConfig = utils.SaveConfig
+
 type Installer struct {
 	*core.Base
 	prompt prompter.Prompter
@@ -84,7 +86,7 @@ func (i *Installer) handleMissingPackages(pkgs []string) ([]string, error) {
 	}
 
 	if anyAdded {
-		if err := utils.SaveConfig(i.Config); err != nil {
+		if err := saveConfig(i.Config); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/prompter/prompter.go
+++ b/internal/prompter/prompter.go
@@ -1,0 +1,51 @@
+package prompter
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Prompter interface {
+	Confirm(question string) (bool, error)
+	Prompt(question string) (string, error)
+}
+
+type TextPrompter struct {
+	in  *bufio.Reader
+	out io.Writer
+}
+
+func New(in io.Reader, out io.Writer) *TextPrompter {
+	return &TextPrompter{
+		in:  bufio.NewReader(in),
+		out: out,
+	}
+}
+
+func (p *TextPrompter) Confirm(q string) (bool, error) {
+	if _, err := fmt.Fprintf(p.out, "%s [y/N]: ", q); err != nil {
+		return false, err
+	}
+
+	resp, err := p.in.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+
+	r := strings.ToLower(strings.TrimSpace(resp))
+	return r == "y" || r == "yes", nil
+}
+
+func (p *TextPrompter) Prompt(q string) (string, error) {
+	if _, err := fmt.Fprint(p.out, q); err != nil {
+		return "", err
+	}
+
+	resp, err := p.in.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(resp), nil
+}


### PR DESCRIPTION
## 📝 Description
Interactive test cases for the installer were exploding with  
`failed to load global config: no configuration found`.  
Root cause: `handleMissingPackages` was writing the global config during
tests.  

**What this PR does**

1. Introduces a `saveConfig` function variable that points to
   `utils.SaveConfig` by default.
2. In the test suite we stub `saveConfig` with a no-op, eliminating
   real I/O.
3. Updates the interactive add/skip tests; the suite is now green.

No production behaviour is changed—only test infrastructure.

## 🔄 Type of Change
<!-- Mark the relevant options with 'x' -->

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring
- [ ] ⚙️ CI/CD pipeline update

## 📋 Checklist
<!-- Mark the relevant options with 'x' -->

- [x] My code follows the project's style guidelines  
- [x] I have updated documentation where needed  
- [x] I have added tests for my changes  
- [x] All new and existing tests pass  
- [x] My changes don’t impact performance negatively  
- [x] I have tested on multiple Linux distributions  
- [x] I have verified Homebrew integration still works  

## 📸 Screenshots
_N/A_

## 🔍 Additional Notes
Stubbing via a function var keeps production untouched while letting
tests run pure memory-only; if more helpers touch disk we can apply the
same pattern.