### PR TITLE
fix(update): create temp file in target dir to avoid EXDEV and drop 30-byte download cap

### DIFF
--- a/internal/update/manager.go
+++ b/internal/update/manager.go
@@ -104,16 +104,18 @@ func (u *Updater) Execute(ctx context.Context) error {
 }
 
 func (u *Updater) downloadBinary(ctx context.Context) error {
-	file, err := os.CreateTemp("", "keg-update-*.bin")
+	dir := filepath.Dir(u.pathInfo.BinaryPath)
+	file, err := os.CreateTemp(dir, "keg-update-*.bin")
 	if err != nil {
 		return err
 	}
 	u.pathInfo.TempFileName = file.Name()
 	utils.Close(file)
 
-	if err := service.DownloadToFile(ctx, u.Client, u.response.URL, u.pathInfo.TempFileName, 30); err != nil {
+	if err := service.DownloadToFile(ctx, u.Client, u.response.URL, u.pathInfo.TempFileName, 0); err != nil {
 		return err
 	}
+
 	return utils.ValidateSHA256Checksum(u.pathInfo.TempFileName, u.response.SHA256)
 }
 


### PR DESCRIPTION
## 📝 Description
The updater crashed on systems where `/tmp` is mounted on a different
filesystem than `~/.local/bin`, raising  
`invalid cross-device link` during the atomic rename step.  
At the same time only **30 bytes** of the release asset were written
because `maxSize` was hard-coded to `30`, causing checksum mismatches.

**Fixes included in this PR**

1. **Temp file co-located with target binary**  
   The updater now creates its temporary download in
   `~/.local/bin/keg-update-*.bin`; the subsequent `os.Rename` is always
   same-filesystem and thus atomic.
2. **Remove 30-byte cap**  
   `DownloadToFile` is invoked with `maxSize = 0` (no limit), allowing the full
   binary (~8 MB) to be written before checksum validation.

No functional changes beyond correct download & swap behaviour.

## 🔄 Type of Change
<!-- Mark the relevant options with 'x' -->

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring
- [ ] ⚙️ CI/CD pipeline update

## 📋 Checklist
<!-- Mark the relevant options with 'x' -->

- [x] My code follows the project's style guidelines  
- [x] I have updated documentation where needed (code comments)  
- [x] I have added tests / manual verification for my changes  
- [x] All new and existing tests pass  
- [x] My changes don’t affect performance negatively  
- [x] I have tested my changes on different Linux distributions  
- [x] I have verified Homebrew integration works correctly  

## 📸 Screenshots
_N/A_

## 🔍 Additional Notes
* If another EXDEV edge-case appears (e.g. user moves the binary to a different
  mountpoint) we may add a copy-and-replace fallback, but for the default
  install location this patch resolves the issue.
