### PR TITLE
upgrade: handle optional packages correctly and badge them in status table

### DIFF
--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -236,7 +236,7 @@ func (b *Base) guardUninstall(isInstalled bool, name string, verb string) error 
 // guardUpgrade decides whether an upgrade should run.
 func (b *Base) guardUpgrade(isInstalled bool, displayName, execName string) (bool, error) {
 	if !isInstalled {
-		logger.LogError("Skipping %s: package not installed", displayName)
+		logger.Info("Skipping %s: package not installed", displayName)
 		return false, nil
 	}
 

--- a/internal/logger/logging.go
+++ b/internal/logger/logging.go
@@ -67,30 +67,6 @@ func Debug(msg string, args ...interface{}) {
 	}
 }
 
-// func CreateTable(headers []string) *tablewriter.Table {
-// 	const (
-// 		MinColWidth       = 20
-// 		PackageColWidth   = 20
-// 		InstalledColWidth = 10
-// 		StatusColWidth    = 15
-// 	)
-// 	table := tablewriter.NewWriter(os.Stdout)
-// 	table.Header(headers)
-// 	table.SetColumnAlignment([]int{
-// 		tablewriter.ALIGN_LEFT,
-// 		tablewriter.ALIGN_CENTER,
-// 		tablewriter.ALIGN_LEFT,
-// 	})
-// 	table.SetBorder(false)
-// 	table.SetColumnSeparator("   ")
-// 	table.SetAutoWrapText(false)
-// 	table.SetColWidth(MinColWidth)             // Minimum width
-// 	table.SetColMinWidth(0, PackageColWidth)   // Package column
-// 	table.SetColMinWidth(1, InstalledColWidth) // Installed column
-// 	table.SetColMinWidth(2, StatusColWidth)    // Status column - increased width
-// 	return table
-// }
-
 func CreateTable(headers []string) *tablewriter.Table {
 	table := tablewriter.NewTable(os.Stdout)
 

--- a/internal/upgrade/manager.go
+++ b/internal/upgrade/manager.go
@@ -45,8 +45,11 @@ func (u *Upgrader) Execute(args []string, checkOnly bool) error {
 		opts.Packages = args
 	}
 
-	opts.ValidateFunc = func(packageName string) bool {
-		return true
+	opts.FilterFunc = func(p *models.Package) bool {
+		if !p.Optional {
+			return true
+		}
+		return u.IsPackageInstalled(u.GetPackageName(p))
 	}
 
 	return u.HandlePackages(opts)

--- a/internal/upgrade/manager.go
+++ b/internal/upgrade/manager.go
@@ -91,20 +91,26 @@ func (u *Upgrader) sortPackages(state *brew.BrewState) packageGroups {
 	return packageGroups{configured: configured, deps: deps}
 }
 
-func (*Upgrader) checkPackageStatus(names []string, st *brew.BrewState, title string) {
+func (u *Upgrader) checkPackageStatus(names []string, st *brew.BrewState, title string) {
 	p := printer.NewColorPrinter()
 
-	statuses := utils.Map(names, func(name string) utils.PackageStatus {
-		status := utils.PackageStatus{Name: name}
+	statuses := utils.Map(names, func(orig string) utils.PackageStatus {
+		nameForLookup, display := orig, orig
 
-		if _, ok := st.Installed[name]; !ok {
+		if pkg, found := u.FindPackage(orig); found && pkg.Optional {
+			display = fmt.Sprintf("%s %s", orig, p.Warning("(opt)"))
+		}
+
+		status := utils.PackageStatus{Name: display}
+
+		if _, ok := st.Installed[nameForLookup]; !ok {
 			status.Installed = p.Error("N")
-			status.Status = p.Error("not found")
+			status.Status = p.Warning("not installed")
 			return status
 		}
 
 		status.Installed = p.Success("Y")
-		if _, outdated := st.Outdated[name]; outdated {
+		if _, outdated := st.Outdated[nameForLookup]; outdated {
 			status.Status = p.Warning("outdated")
 		} else {
 			status.Status = p.Success("up to date")


### PR DESCRIPTION
## 📝 Description
This PR delivers two related improvements to the `keg upgrade` workflow:

1. **fix(upgrade): include installed optional packages in bulk upgrade**  
   `keg upgrade` now upgrades optional packages when they are already
   installed.  
   The new `FilterFunc` keeps optionals in the list only if
   `IsPackageInstalled` returns true.

2. **style(upgrade-table): add ‘(opt)’ badge to optional packages**  
   In `keg upgrade --check` (and other status tables) optional packages are
   now suffixed with a colored `(opt)` tag, making their nature explicit
   while keeping the table width unchanged.

No breaking changes; behavior for required packages is untouched.

## 🔗 Related Issue(s)
*None*

## 🔄 Type of Change
<!-- Mark the relevant options with 'x' -->

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] 💅 Style/UI improvement
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring
- [ ] ⚙️ CI/CD pipeline update

## 📋 Checklist
<!-- Mark the relevant options with 'x' -->

- [x] My code follows the project's style guidelines  
- [x] I have added or updated tests where necessary  
- [x] All new and existing tests pass  
- [x] My changes don’t affect performance negatively  
- [x] I have tested my changes on different Linux distributions  
- [x] I have verified Homebrew integration works correctly  

## 📸 Screenshots
_(see comment thread for before/after table)_

## 🔍 Additional Notes
* The badge is applied only for display; internal look-ups keep using the
  original package name, preventing false “not installed” states.
* If at least one package in the list is optional the badge appears; otherwise
  the table is identical to previous releases.