### PR TITLE
docs(roadmap), chore(hooks): roadmap update & conditional golangci-lint

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -12,7 +12,14 @@ if ! go build ./...; then
   exit 1
 fi
 
-echo "Running linters..."
+staged_go_files=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
+
+if [ -z "$staged_go_files" ]; then
+  echo "No Go files changed. Skipping golangci-lint."
+  exit 0
+fi
+
+echo "Running linters on Go files..."
 if ! golangci-lint run --config .golangci.yml; then
   echo "Error: Linting issues detected."
   exit 1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,20 +33,14 @@
 - [x] Polish logging
 - [x] Autoupdate of keg cli
 
-## v0.2 - Advanced usability
+## v0.2 — Quality-of-Life & Performance
+- [ ] **Remote registry support**  
+      Import packages from a hosted YAML (GitHub raw, Gist, S3…)
+- [ ] **Package search**  
+      `keg search fzf` → query Homebrew formulae and display metadata
 
-- [ ] Multi-profiles support (~/.config/keg/profiles/)
-- [ ] Custom config locations
-- [ ] Basic plugin system
-- [ ] Global `--dry-run / -n` flag
-- [ ] Centralized AppFlags struct for global CLI flags
-- [ ] Propagate dry-run flag to all commands
-- [ ] Refactor command logic to respect dry-run behavior
-- [ ] Optional: Introduce ConfigSaver interface for dry-run vs. real saves
-
-## v0.3 - Major improvements
-
-- [ ] Caching downloaded packages
-- [ ] Hooks system (pre/post install scripts)
-- [ ] Remote registries support
-- [ ] Package search
+## v1.0 — Plugin ecosystem
+- [ ] Stable plugin API (dynamically-loaded `.so` or scripts)
+- [ ] **Hook system** (pre- / post-install shell or Go plugins)
+- [ ] `keg <plugin> [...]` command injection
+- [ ] Marketplace template & official docs


### PR DESCRIPTION
## 📝 Description
This pull request introduces two focused improvements:

1. **Roadmap update**  
   - Adds the upcoming **remote registry & search** feature.  
   - Defers hooks and plugins work to version 1.0 for clearer milestone alignment.

2. **Pre-commit hook refinement**  
   - Updates the `pre-commit` script to run `golangci-lint` only when staged files include at least one `.go` file, reducing unnecessary CI workload.

## 🔗 Related Issue(s)
<!-- Link issues as needed -->
- Fixes #
- Related to #

## 🔄 Type of Change
<!-- Mark all that apply with “x” -->

- [ ] 🐛 Bug fix (non-breaking change)
- [ ] ✨ New feature (non-breaking change)
- [ ] 💥 Breaking change
- [x] 📚 Documentation update
- [x] ⚙️ CI/CD pipeline update

## 📋 Checklist
<!-- Mark all that apply with “x” -->

- [x] Code follows the project’s style guidelines.  
- [x] Documentation has been updated.  
- [ ] Tests have been added or updated.  
- [x] All existing tests pass.  
- [x] No negative performance impact has been introduced.  
- [ ] Changes have been validated on multiple Linux distributions.  
- [ ] Homebrew integration has been verified, if applicable.  

## 📸 Screenshots
_Not applicable._

## 🔍 Additional Notes
The conditional linter execution can be reverted to full-project linting by removing the staged-files filter should future requirements change.