### PR TITLE
refactor(cli): implement middleware factory and context system for shared pre-run logic

### DIFF
--- a/internal/add.go
+++ b/internal/add.go
@@ -2,7 +2,8 @@ package internal
 
 import (
 	"github.com/MrSnakeDoc/keg/internal/add"
-	"github.com/MrSnakeDoc/keg/internal/utils"
+	"github.com/MrSnakeDoc/keg/internal/middleware"
+	"github.com/MrSnakeDoc/keg/internal/models"
 
 	"github.com/spf13/cobra"
 )
@@ -20,7 +21,7 @@ Examples:
   keg add --optional bat starship # Add multiple optional packages
   keg add --binary=batcat bat     # Add package with different binary name (single package only)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := utils.PreliminaryChecks()
+			cfg, err := middleware.Get[*models.Config](cmd, middleware.CtxKeyConfig)
 			if err != nil {
 				return err
 			}

--- a/internal/bootstrap.go
+++ b/internal/bootstrap.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"github.com/MrSnakeDoc/keg/internal/bootstraper"
-	"github.com/MrSnakeDoc/keg/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -17,14 +16,8 @@ func NewBootstrapCmd() *cobra.Command {
     - If not, prompt to install zsh
     - Set zsh as the default shell`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			// Load config first
-			cfg, err := utils.PreliminaryChecks()
-			if err != nil {
-				return err
-			}
-
 			// Create bootstraper
-			boot := bootstraper.New(cfg, nil)
+			boot := bootstraper.New(nil)
 
 			// Run deployment
 			return boot.Execute()

--- a/internal/bootstraper/bootstraper_test.go
+++ b/internal/bootstraper/bootstraper_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/MrSnakeDoc/keg/internal/models"
 	"github.com/MrSnakeDoc/keg/internal/runner"
 	"github.com/MrSnakeDoc/keg/internal/utils"
 )
@@ -64,7 +63,7 @@ func TestRunPackageManagerCommand_AllManagers(t *testing.T) {
 
 			// ── 2.  Bootstraper with MockRunner ───────────────────────────
 			mockRun := runner.NewMockRunner()
-			bs := New(&models.Config{}, mockRun)
+			bs := New(mockRun)
 
 			if err := bs.runPackageManagerCommand(tc.cmd); err != nil {
 				t.Fatalf("runPackageManagerCommand err: %v", err)

--- a/internal/bootstraper/manager.go
+++ b/internal/bootstraper/manager.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/MrSnakeDoc/keg/internal/logger"
-	"github.com/MrSnakeDoc/keg/internal/models"
 	"github.com/MrSnakeDoc/keg/internal/runner"
 	"github.com/MrSnakeDoc/keg/internal/utils"
 )
@@ -24,7 +23,6 @@ import (
 // Description:
 // This struct encapsulates the logic for installing and configuring ZSH as the default shell.
 type Bootstraper struct {
-	Config *models.Config
 	Runner runner.CommandRunner
 }
 
@@ -50,12 +48,11 @@ type packageManagerCommands struct {
 //
 // Notes:
 // If no runner is provided, a default StreamingRunner is used.
-func New(config *models.Config, r runner.CommandRunner) *Bootstraper {
+func New(r runner.CommandRunner) *Bootstraper {
 	if r == nil {
 		r = &runner.ExecRunner{}
 	}
 	return &Bootstraper{
-		Config: config,
 		Runner: r,
 	}
 }

--- a/internal/commands.go
+++ b/internal/commands.go
@@ -1,22 +1,21 @@
 package internal
 
 import (
+	"github.com/MrSnakeDoc/keg/internal/middleware"
 	"github.com/spf13/cobra"
 )
 
-type CommandFactory func() *cobra.Command
-
-var defaultCommands = []CommandFactory{
-	NewBootstrapCmd,
+var defaultCommands = []middleware.CommandFactory{
 	NewInitCmd,
 	NewListCmd,
-	NewDeployCmd,
-	NewInstallCmd,
-	NewUpgradeCmd,
-	NewDeleteCmd,
-	NewAddCmd,
-	NewRemoveCmd,
-	NewUpdateCmd,
+	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewBootstrapCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewDeployCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewInstallCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewUpgradeCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewDeleteCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewAddCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewRemoveCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewUpdateCmd),
 }
 
 func RegisterSubCommands(cmd *cobra.Command) {

--- a/internal/commands.go
+++ b/internal/commands.go
@@ -7,15 +7,15 @@ import (
 
 var defaultCommands = []middleware.CommandFactory{
 	NewInitCmd,
-	NewListCmd,
-	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewBootstrapCmd),
-	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewDeployCmd),
-	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewInstallCmd),
-	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewUpgradeCmd),
-	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewDeleteCmd),
-	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewAddCmd),
-	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewRemoveCmd),
-	middleware.UseMiddlewareChain(middleware.RequireConfig)(NewUpdateCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig, middleware.IsHomebrewInstalled, middleware.LoadPkgList)(NewListCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig, middleware.IsHomebrewInstalled)(NewBootstrapCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig, middleware.IsHomebrewInstalled, middleware.LoadPkgList)(NewDeployCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig, middleware.IsHomebrewInstalled, middleware.LoadPkgList)(NewInstallCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig, middleware.IsHomebrewInstalled, middleware.LoadPkgList)(NewUpgradeCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig, middleware.IsHomebrewInstalled, middleware.LoadPkgList)(NewDeleteCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig, middleware.IsHomebrewInstalled, middleware.LoadPkgList)(NewAddCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig, middleware.IsHomebrewInstalled, middleware.LoadPkgList)(NewRemoveCmd),
+	middleware.UseMiddlewareChain(middleware.RequireConfig, middleware.IsHomebrewInstalled, middleware.LoadPkgList)(NewUpdateCmd),
 }
 
 func RegisterSubCommands(cmd *cobra.Command) {

--- a/internal/delete.go
+++ b/internal/delete.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
+	"github.com/MrSnakeDoc/keg/internal/middleware"
+	"github.com/MrSnakeDoc/keg/internal/models"
 	"github.com/MrSnakeDoc/keg/internal/uninstall"
-	"github.com/MrSnakeDoc/keg/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -19,7 +20,7 @@ Examples:
   keg delete bat starship    # Delete multiple packages
   keg delete --all          # Delete all packages from config`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := utils.PreliminaryChecks()
+			cfg, err := middleware.Get[*models.Config](cmd, middleware.CtxKeyConfig)
 			if err != nil {
 				return err
 			}

--- a/internal/deploy.go
+++ b/internal/deploy.go
@@ -2,7 +2,8 @@ package internal
 
 import (
 	"github.com/MrSnakeDoc/keg/internal/deploy"
-	"github.com/MrSnakeDoc/keg/internal/utils"
+	"github.com/MrSnakeDoc/keg/internal/middleware"
+	"github.com/MrSnakeDoc/keg/internal/models"
 
 	"github.com/spf13/cobra"
 )
@@ -17,12 +18,11 @@ This includes:
 - Installing Homebrew if not present
 - Installing all configured packages
 - Running post-installation steps`,
-		RunE: func(_ *cobra.Command, _ []string) error {
-			cfg, err := utils.PreliminaryChecks()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := middleware.Get[*models.Config](cmd, middleware.CtxKeyConfig)
 			if err != nil {
 				return err
 			}
-
 			// Create deployer
 			dep := deploy.New(cfg, nil)
 

--- a/internal/install.go
+++ b/internal/install.go
@@ -2,7 +2,8 @@ package internal
 
 import (
 	"github.com/MrSnakeDoc/keg/internal/install"
-	"github.com/MrSnakeDoc/keg/internal/utils"
+	"github.com/MrSnakeDoc/keg/internal/middleware"
+	"github.com/MrSnakeDoc/keg/internal/models"
 
 	"github.com/spf13/cobra"
 )
@@ -19,7 +20,7 @@ Examples:
     keg install lazygit asdf # Installs base packages + lazygit and asdf
     keg install --all        # Installs all packages, including optional ones`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := utils.PreliminaryChecks()
+			cfg, err := middleware.Get[*models.Config](cmd, middleware.CtxKeyConfig)
 			if err != nil {
 				return err
 			}

--- a/internal/list.go
+++ b/internal/list.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 
 	"github.com/MrSnakeDoc/keg/internal/logger"
+	"github.com/MrSnakeDoc/keg/internal/middleware"
+	"github.com/MrSnakeDoc/keg/internal/models"
 	"github.com/MrSnakeDoc/keg/internal/printer"
 	"github.com/MrSnakeDoc/keg/internal/runner"
 	"github.com/MrSnakeDoc/keg/internal/utils"
@@ -16,8 +18,8 @@ func NewListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "List all configured packages and their status",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			cfg, err := utils.PreliminaryChecks()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := middleware.Get[*models.Config](cmd, middleware.CtxKeyConfig)
 			if err != nil {
 				return err
 			}

--- a/internal/middleware/homebrewCheck.go
+++ b/internal/middleware/homebrewCheck.go
@@ -1,8 +1,9 @@
-package utils
+package middleware
 
 import (
 	"github.com/MrSnakeDoc/keg/internal/logger"
-	"github.com/MrSnakeDoc/keg/internal/models"
+	"github.com/MrSnakeDoc/keg/internal/utils"
+	"github.com/spf13/cobra"
 )
 
 func WarningBrewMessages() {
@@ -13,16 +14,11 @@ func WarningBrewMessages() {
 	logger.Warn("Or use the command: plugins deploy")
 }
 
-func PreliminaryChecks() (*models.Config, error) {
-	cfg, err := LoadConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	if !IsHomebrewInstalled() {
+func IsHomebrewInstalled(cmd *cobra.Command, args []string, next func(cmd *cobra.Command, args []string) error) error {
+	if !utils.IsHomebrewInstalled() {
 		WarningBrewMessages()
-		return cfg, nil
+		return nil
 	}
 
-	return cfg, nil
+	return next(cmd, args)
 }

--- a/internal/middleware/loadPkgList.go
+++ b/internal/middleware/loadPkgList.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"context"
+
+	"github.com/MrSnakeDoc/keg/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func LoadPkgList(cmd *cobra.Command, args []string, next func(cmd *cobra.Command, args []string) error) error {
+	cfg, err := utils.LoadConfig()
+	if err != nil {
+		return err
+	}
+
+	ctx := context.WithValue(cmd.Context(), CtxKeyConfig, cfg)
+	cmd.SetContext(ctx)
+
+	return next(cmd, args)
+}

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type CommandFactory func() *cobra.Command
+
+type MiddlewareFunc func(cmd *cobra.Command, args []string, next func(cmd *cobra.Command, args []string) error) error
+
+type MiddlewareChain func(factory CommandFactory) CommandFactory
+
+func UseMiddlewareChain(middlewares ...MiddlewareFunc) MiddlewareChain {
+	return func(factory CommandFactory) CommandFactory {
+		return func() *cobra.Command {
+			cmd := factory()
+
+			original := cmd.PreRunE
+
+			cmd.PreRunE = func(c *cobra.Command, args []string) error {
+				var chain func(cmd *cobra.Command, args []string) error
+				chain = func(cmd *cobra.Command, args []string) error {
+					if original != nil {
+						return original(cmd, args)
+					}
+					return nil
+				}
+
+				for i := len(middlewares) - 1; i >= 0; i-- {
+					mw := middlewares[i]
+					next := chain
+					chain = func(cmd *cobra.Command, args []string) error {
+						return mw(cmd, args, next)
+					}
+				}
+
+				return chain(c, args)
+			}
+
+			return cmd
+		}
+	}
+}

--- a/internal/middleware/requirePersistantConfig.go
+++ b/internal/middleware/requirePersistantConfig.go
@@ -12,5 +12,6 @@ func RequireConfig(cmd *cobra.Command, args []string, next func(cmd *cobra.Comma
 	if err != nil {
 		return fmt.Errorf("missing config: %w", err)
 	}
+
 	return next(cmd, args)
 }

--- a/internal/middleware/require_config.go
+++ b/internal/middleware/require_config.go
@@ -1,0 +1,16 @@
+package middleware
+
+import (
+	"fmt"
+
+	"github.com/MrSnakeDoc/keg/internal/globalconfig"
+	"github.com/spf13/cobra"
+)
+
+func RequireConfig(cmd *cobra.Command, args []string, next func(cmd *cobra.Command, args []string) error) error {
+	_, err := globalconfig.LoadPersistentConfig()
+	if err != nil {
+		return fmt.Errorf("missing config: %w", err)
+	}
+	return next(cmd, args)
+}

--- a/internal/remove.go
+++ b/internal/remove.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
+	"github.com/MrSnakeDoc/keg/internal/middleware"
+	"github.com/MrSnakeDoc/keg/internal/models"
 	"github.com/MrSnakeDoc/keg/internal/remove"
-	"github.com/MrSnakeDoc/keg/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -17,7 +18,7 @@ Examples:
   keg remove bat                     # Remove single package
   keg remove bat starship            # Remove multiple packages`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := utils.PreliminaryChecks()
+			cfg, err := middleware.Get[*models.Config](cmd, middleware.CtxKeyConfig)
 			if err != nil {
 				return err
 			}

--- a/internal/root.go
+++ b/internal/root.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/MrSnakeDoc/keg/internal/checker"
-	"github.com/MrSnakeDoc/keg/internal/globalconfig"
 	"github.com/MrSnakeDoc/keg/internal/logger"
 	"github.com/MrSnakeDoc/keg/internal/notifier"
 
@@ -21,17 +20,9 @@ func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "keg",
 		Short: "Package installer for development environment",
-		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-			if cmd.Name() == "init" {
-				return nil
-			}
-
-			_, err := globalconfig.LoadPersistentConfig()
-			if err != nil {
-				return fmt.Errorf("keg is not initialized, please run 'keg init' first: %w", err)
-			}
-			return nil
-		},
+		Long: `Keg is a package installer designed to simplify the setup and management of development environments.
+It allows you to easily install, update, and manage packages and dependencies for your projects.`,
+		Example: `keg install lazygit asdf`,
 		Run: func(cmd *cobra.Command, _ []string) {
 			versionFlag, _ := cmd.Flags().GetBool("version")
 			if versionFlag {

--- a/internal/upgrade.go
+++ b/internal/upgrade.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
+	"github.com/MrSnakeDoc/keg/internal/middleware"
+	"github.com/MrSnakeDoc/keg/internal/models"
 	"github.com/MrSnakeDoc/keg/internal/upgrade"
-	"github.com/MrSnakeDoc/keg/internal/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -19,7 +20,7 @@ Examples:
   keg upgrade --check/-c 		# Checks for available upgrades
   keg upgrade --check/-c bat 	# Checks upgrades for specific package`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := utils.PreliminaryChecks()
+			cfg, err := middleware.Get[*models.Config](cmd, middleware.CtxKeyConfig)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## 📝 Description
This PR introduces a new middleware factory and context-based system for the CLI to simplify and centralize shared pre-run logic. Instead of manually reloading the config or checking prerequisites in every command, we now use middleware that injects required values (like the config or brew check results) into `cmd.Context()`.

Commands can now access data like the persistent config via a generic and type-safe helper, reducing redundancy and improving code clarity.

Main changes:
- Introduced `useMiddlewareChain()` to wrap command factories with composable middlewares
- Added `RequireConfig`, `LoadPkgList`, and `HomebrewCheck` middlewares
- Context system uses typed keys and a `Get[T]()` helper for safe extraction
- Updated all affected commands to consume the injected context values
- Removed duplicate config loading logic (`utils.PreliminaryChecks` is gone)

## 🔗 Related Issue(s)
- Fixes #<!-- If there's a specific issue, drop it here -->
- Related to #<!-- Optional -->

## 🔄 Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📚 Documentation update
- [x] 🔧 Code refactoring
- [ ] ⚙️ CI/CD pipeline update

## 📋 Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [ ] I have added tests for my changes
- [x] All new and existing tests pass
- [x] My changes don't affect performance negatively
- [x] I have tested my changes on different Linux distributions
- [x] I have verified Homebrew integration works correctly

## 📸 Screenshots (if applicable)
N/A

## 🔍 Additional Notes
This system is fully generic and extensible. You can now pass any data via middleware to commands safely using context injection. This is a big step forward for maintainability and modularity.