### PR TITLE
chore(cicd): fix goversion injection during build

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -15,13 +15,14 @@ builds:
       - -X github.com/MrSnakeDoc/keg/internal/checker.Version={{.Version}}
       - -X github.com/MrSnakeDoc/keg/internal/checker.Commit={{.Commit}}
       - -X github.com/MrSnakeDoc/keg/internal/checker.Date={{.Date}}
-      - -X github.com/MrSnakeDoc/keg/internal/checker.GoVersion={{.GoVersion}}
+      - -X github.com/MrSnakeDoc/keg/internal/checker.GoVersion={{.Env.GOVERSION}}
     goos:
       - linux
     goarch:
       - amd64
     env:
       - CGO_ENABLED=0
+      - GOVERSION={{.Env.GOVERSION}}
     binary: keg
 
 archives:


### PR DESCRIPTION
## 📝 Description
Fix GoReleaser build issue by properly injecting `GoVersion` during build.  
This ensures release metadata is consistent and prevents pipeline failures on tag builds.

## 🔗 Related Issue(s)
- Fixes # (none directly, but addresses CI/CD release failure)

## 🔄 Type of Change
- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📚 Documentation update
- [ ] 🔧 Code refactoring
- [x] ⚙️ CI/CD pipeline update

## 📋 Checklist
- [x] My code follows the project's style guidelines
- [x] All new and existing tests pass
- [x] My changes don't affect performance negatively
- [x] I have verified the release pipeline builds correctly

## 🔍 Additional Notes
No user-facing changes. Internal CI/CD fix only.